### PR TITLE
fix syntax error due to usage of let

### DIFF
--- a/webpack-licenses-plugin.js
+++ b/webpack-licenses-plugin.js
@@ -1,3 +1,4 @@
+'use strict';
 const path = require('path')
 
 function validateConfig(conf) {


### PR DESCRIPTION
webpack-licenses-plugin.js:18
  let license
  ^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode